### PR TITLE
Add Dockerfile for Electron App Containerization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:19.04.0-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+EXPOSE 3000
+ENV PORT 3000
+CMD ["npm","run","electron:start"]


### PR DESCRIPTION
## Title: Add Dockerfile for Electron App Containerization

### Changes Made:
- **Added Dockerfile:** A new Dockerfile was created to containerize the Electron app. This Dockerfile sets up a Node.js environment, installs dependencies, copies the application code, and runs the app on port 3005 using `npm run electron:start`.

### Manual Testing Done:
1. **Build the Docker Image:**
   ```bash
   docker build -t my-electron-app .
   ```
   - Verified that the Docker image was built successfully without any errors.

2. **Run the Docker Container:**
   ```bash
   docker run -d -p 3005:3005 --name electron-app-container my-electron-app
   ```
   - Confirmed that the container starts and the app is accessible via `http://localhost:3005`.

3. **Check Running Containers:**
   ```bash
   docker ps
   ```

**Tharindu Jayawardhana**  
Frontend Developer at LifePill
